### PR TITLE
Disable RSpec/DescribeClass cop for tasks, requests and view specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v0.6.2
 
+## Features
+
+* Disable RSpec/DescribeClass cop for tasks, requests and view specs
+
 ## Bugfixes
 
 * Fix CommitMessage validation to pass a merge message with a type prefix

--- a/fuse-dev-tools.gemspec
+++ b/fuse-dev-tools.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.' unless spec.respond_to?(:metadata)
+
   spec.metadata['allowed_push_host'] = 'https://github.com/Fuseit/fuse-dev-tools'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|

--- a/lib/fuse_dev_tools/templates/.rubocop_rspec.yml
+++ b/lib/fuse_dev_tools/templates/.rubocop_rspec.yml
@@ -13,6 +13,11 @@ RSpec/ContextWording:
     - without
     - and
     - but
+RSpec/DescribeClass:
+  Exclude:
+    - spec/lib/tasks/**/*.rake_spec.rb
+    - spec/requests/**/*_spec.rb
+    - spec/views/**/*_spec.rb
 RSpec/ExampleLength:
   Max: 3
   Exclude:


### PR DESCRIPTION
https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecdescribeclass

This cop gives false positives in view specs, which have a string a the first argument:

```ruby
RSpec.describe 'fuse_audience_management_app/audiences/_profile_fields.json.rabl' do
  # ...
end
```

And request specs:

```ruby
RSpec.describe 'Wizard', type: :request do
  # ...
end
```

And tasks specs:

```ruby
RSpec.describe 'db:structure:format', rake: true do
  # ...
end
```