### PR TITLE
feature SAS-309 Add test presence validation to build checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,27 @@
+## v0.7.0
+
+### Features
+
+* SAS-309 Add test presence validation to build checks
+
+
 ## v0.6.1
 
-## Bugfixes
+### Bugfixes
 
 * Fix CommitMessage validation to read from working directory
 
 
 ## v0.6.0
 
-## Features
+### Features
 
 * Add CommitMessage validation
 
 
 ## v0.5.0
 
-## Features
+### Features
 
 * CS-36 Add default Rubocop config for use in projects
 


### PR DESCRIPTION
It appears feature, fix and hotfix PRs are being approved even though they do not contain tests. All of these PRs must contain specs in their associated areas so the purpose of this task is to fail any task that does not contain new tests written in the PR.