### PR TITLE
Fix ruby style method parentheses

### DIFF
--- a/lib/fuse_dev_tools/templates/rubocop/cops_style.yml
+++ b/lib/fuse_dev_tools/templates/rubocop/cops_style.yml
@@ -28,9 +28,6 @@ Style/InlineComment:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
-# NOTE: Default is to require parentheses, however due to legacy decisions we set to require none...
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses
 Style/NonNilCheck:
   IncludeSemanticChanges: true
 # Only allowed keyword is `options`


### PR DESCRIPTION
https://github.com/rubocop-hq/ruby-style-guide#method-parens