### PR TITLE
Change formatting to use JIRA links instead of only using the ticket

### DIFF
--- a/lib/fuse_dev_tools/lib/changelog_builder.rb
+++ b/lib/fuse_dev_tools/lib/changelog_builder.rb
@@ -1,6 +1,8 @@
 require 'active_support/core_ext/string'
 
 class ChangelogBuilder
+  JIRA_URL = 'https://fuseuniversal.atlassian.net'.freeze
+
   def initialize commits
     @commits = commits
   end
@@ -37,8 +39,10 @@ class ChangelogBuilder
       end
     end
 
-    def format_commit_message message, sha
-      '* ' + message.split(' ').drop(1).join(' ') + " ##{sha}"
+    def format_commit_message line, sha
+      split_line = line.split(' ')
+      _, jira_ticket = split_line.shift(2)
+      "* [#{jira_ticket}](#{JIRA_URL}/browse/#{jira_ticket}): #{split_line.join(' ')} ##{sha}"
     end
 
     def categorize_by_message_type message, type

--- a/spec/lib/changelog_builder_spec.rb
+++ b/spec/lib/changelog_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ChangelogBuilder do
     let(:message) { 'fix TEST-1 First thingy' }
     let(:sha) { '123asewq' }
 
-    it { is_expected.to eq '* TEST-1 First thingy #123asewq' }
+    it { is_expected.to eq "* [TEST-1](#{described_class::JIRA_URL}/browse/TEST-1): First thingy #123asewq" }
   end
 
   describe '#categorize_commits' do
@@ -56,8 +56,11 @@ RSpec.describe ChangelogBuilder do
   describe '#build' do
     subject(:build) { builder.build }
 
+    before do
+      allow(builder).to receive(:categorize_commits).and_call_original
+    end
+
     it 'builds categorised changelod string' do
-      allow(builder).to receive(:categorize_commits)
       build
       expect(builder).to have_received(:categorize_commits)
     end


### PR DESCRIPTION
Edit the message formatting to include JIRA ticket link in the changelog generation.