### PR TITLE
feature FUSE-1720 Make sure repository is updated

### DIFF
--- a/bin/tag-and-release
+++ b/bin/tag-and-release
@@ -11,7 +11,16 @@ tag_and_release() {
     RUBYOPT="-W0" ./bin/fuse-dev-tools changelog_generator preview --repo $application > $tempfile1
     sed "1s/.*/$version/" $tempfile1 > $tempfile2
 
+    echo "Moving to ${application} folder"
     cd "../$application" || exit
+
+    echo "Updating the ${application} repository"
+    git checkout master
+    git pull -r
+
+    echo "Creating and pushing 'release-${version:1}' branch"
+    git checkout -b release-${version:1}
+    git push origin release-${version:1}
 
     echo "Tagging ${application} ${version}"
     git tag -a $version -m $version || exit
@@ -23,6 +32,11 @@ tag_and_release() {
 cleanup() {
   echo "Removing temporary files"
   rm  -r $tempfile1 $tempfile2
+
+  echo "Deleting local 'release-${version:1}' artifacts"
+  git checkout master
+  git branch -D release-${version:1}
+  git tag -D $version
 }
 
 trap cleanup EXIT
@@ -42,7 +56,6 @@ while getopts "a:v:?h" o; do
 done
 
 shift $((OPTIND-1))
-
 
 if [ -z "${application}" ] || [ -z "${version}" ]; then
     usage


### PR DESCRIPTION
Issue:
* We want to run the release for the latest code in master, so we need
  to make sure that the code we're working on is the latest.

Why:
* So we don't release outdated versions of the app

Improvements:
* Update repository before branching and tagging
* Delete local release branches that are of little to no use for
  developers
* Push newly created branches to GitHub