### PR TITLE
Prepend version with `v` when creating the release

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -75,7 +75,7 @@ tag_and_release() {
     git tag -a "v$version" -m "Release v$version" || exit
 
     echo "Releasing $application $version"
-    hub release create $version --file $tempfile2 || exit
+    hub release create "v$version" --file $tempfile2 || exit
 }
 
 generate_commit_tag_and_release() {


### PR DESCRIPTION
I missed a `v` in the tag, which created 2 tags - one with `v` prepended and one without. This fixes it