### PR TITLE
chore Release creation script accepts branches other than master

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-usage() { echo "Usage: $0 [-a <application>] [-b <bump>]" 1>&2; exit 1; }
+usage() { echo "Usage: $0 -a <application> -b <bump> -t <target>" 1>&2; exit 1; }
 
 validate_command_exists() {
     local cmd=$1
@@ -16,21 +16,23 @@ validate_command_exists hub
 
 generate_changelog() {
     local application=$1
-    local version=$2
+    local new_version=$2
+    local target_branch=$3
     markdown_changelog=$(mktemp)
 
     echo Generating changelog...
-    RUBYOPT="-W0" ./bin/fuse-dev-tools changelog_generator preview --repo $application --version $version > $markdown_changelog
+    RUBYOPT="-W0" ./bin/fuse-dev-tools changelog_generator preview --repo $application --version $new_version --target_branch $target_branch > $markdown_changelog
 }
 
 move_to_directory_and_update() {
     local application=$1
+    local target_branch=$2
 
     echo "Moving to $application..."
     cd "../$application" || exit
     echo Stashing current changes
     git stash
-    git checkout master
+    git checkout $target_branch
     git pull -r
 }
 
@@ -44,25 +46,27 @@ prepend_changelog_and_bump_version() {
     echo "v$version" > VERSION
 }
 
-commit_to_master() {
-    local version=$1
+commit_to_branch() {
+    local target_branch=$1
+    local version=$2
 
     echo Creating a bump version commit
     git commit -a -m "chore Bump version to v$version"
-    echo Pushing to the master
+    echo Pushing to the $target_branch branch
     git push
 }
 
 tag_and_release() {
     local application=$1
     local version=$2
+    local target_branch=$3
 
     tempfile2=$(mktemp)
 
     sed "1s/.*/v$version/" $markdown_changelog > $tempfile2
 
     echo "Updating ${application} repository"
-    git checkout master
+    git checkout $target_branch
     git pull -r
 
     echo release-$version
@@ -80,22 +84,25 @@ tag_and_release() {
 
 generate_commit_tag_and_release() {
     local application=$1
-    local version=$2
+    local new_version=$2
 
-    generate_changelog $application $version
-    move_to_directory_and_update $application
-    prepend_changelog_and_bump_version $version
-    commit_to_master $version
-    tag_and_release $application $version
+    generate_changelog $application $new_version $target_branch
+    move_to_directory_and_update $application $target_branch
+    prepend_changelog_and_bump_version $new_version
+    commit_to_branch $target_branch $new_version
+    tag_and_release $application $new_version $target_branch
 }
 
-while getopts "a:b:?h" o; do
+while getopts "a:b:t:?h" o; do
     case "${o}" in
         a)
             application=${OPTARG}
             ;;
         b)
             bump=${OPTARG}
+            ;;
+        t)
+            target_branch=${OPTARG}
             ;;
         h)
             usage
@@ -105,7 +112,7 @@ done
 
 shift $((OPTIND-1))
 
-if [ -z "${application}" ] || [ -z "${bump}" ]; then
+if [ -z "${application}" ] || [ -z "${bump}" ] || [ -z "${target_branch}" ]; then
     usage
 fi
 
@@ -140,6 +147,22 @@ calculate_new_version() {
     "patch")
       patch=$((patch+1))
       ;;
+    "minor-pre")
+      minor=$((minor+1))
+      patch="0-pre1"
+      echo "minor-pre bump, with resulting patch: ${patch}"
+      ;;
+    "patch-pre")
+      # Expecting patches of the form "1" or "3-pre4"
+      case $patch in
+        [1-9])
+          patch=$((${patch}+1))-pre0
+          ;;
+        *)
+          patch=${patch%%-pre*}-pre$((${patch#*-pre}+1))
+          ;;
+      esac
+      ;;
   esac
 
   local new_version="${major}.${minor}.${patch}"
@@ -153,7 +176,7 @@ echo "The application is ${application} and the version is ${new_version}"
 
 read -p "Continue (y/n)? " choice
 case "$choice" in
-    y|Y ) generate_commit_tag_and_release $application $new_version;;
+    y|Y ) generate_commit_tag_and_release $application $new_version $target_branch;;
     n|N ) exit 0;;
     * ) echo "invalid";;
 esac

--- a/lib/fuse_dev_tools/tasks/changelog_generator.rb
+++ b/lib/fuse_dev_tools/tasks/changelog_generator.rb
@@ -8,6 +8,7 @@ module FuseDevTools
       option 'bump', desc: 'Bump: pre, patch, minor, major', default: 'patch'
       option 'repo', desc: 'Repo name if different than current'
       option 'version', desc: 'Full version number of the release'
+      option 'target_branch', desc: 'Git branch'
       def preview
         @repo ||= options['repo']
         puts format_changelog options['bump'].to_sym
@@ -53,12 +54,12 @@ module FuseDevTools
           GitHub.previous_release_version org, repo
         end
 
-        def commits
-          GitHub.comparison_message_commits org, repo, "v#{previous_release_version}", 'HEAD'
+        def commits target_branch = 'HEAD'
+          GitHub.comparison_message_commits org, repo, "v#{previous_release_version}", target_branch
         end
 
         def format_changelog bump
-          builder = ChangelogBuilder.new commits
+          builder = ChangelogBuilder.new commits(options['target_branch'])
 
           if options['version'] && options['version'] <= previous_release_version
             raise ArgumentError, 'Please provide a version higher than the previous version'


### PR DESCRIPTION
## Problem
The new release and deployment process depends on non-master
branches; the create-release script assumed master everywhere. In
order to accommodate this, engineers were manually creating releases,
which bypasses the protections (and labour-saving automation!) of the
script.

## Solution
Fix the script.
- Require a target_branch parameter, allowing us to create releases
  from branches other than master.

## Example
Without running the entire script, just generating the changelog:
```shell
nano .ruby-version  # to put in place ruby 2.4.10, to bypass some of the pre-existing issues with concurrent/map
GITHUB_ACCESS_TOKEN=<redacted> RUBYOPT="-W0" ./bin/fuse-dev-tools changelog_generator preview --repo FuseTube --version 3.62.0-pre1 --target_branch increment-2-2021

## v3.62.0-pre1 - 2021-03-17 14:39:13 +0200




### Technical improvements

* [PD-159](https://fuseuniversal.atlassian.net/browse/PD-159): increase size of evidence portfolio uploads (#7521) 68e2c81
```