### PR TITLE
chore Release creation tidying up version handling

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -150,7 +150,6 @@ calculate_new_version() {
     "minor-pre")
       minor=$((minor+1))
       patch="0-pre1"
-      echo "minor-pre bump, with resulting patch: ${patch}"
       ;;
     "patch-pre")
       # Expecting patches of the form "1" or "3-pre4"

--- a/lib/fuse_dev_tools/lib/git_hub.rb
+++ b/lib/fuse_dev_tools/lib/git_hub.rb
@@ -9,6 +9,7 @@ class GitHub
   def self.previous_release_version username, repo
     latest_release = client.latest_release("#{username}/#{repo}")[:name]
     latest_release.slice!(0)
+    latest_release.gsub!(/ .*$/, '')
     Semantic::Version.new(latest_release)
   end
 


### PR DESCRIPTION
## Problems
- Bash script version-bump case statement broken by echo
- GitHub wrapper tripped up by malformed GitHub release names

## Solution
- Remove the echo from the version-bump case statement, as it was
  cosmetic
- Remove anything after the first space in the release name, and Try
  to create a Semantic Version from that first part only.