### PR TITLE
chore Release creation passes target branch correctly

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -85,6 +85,7 @@ tag_and_release() {
 generate_commit_tag_and_release() {
     local application=$1
     local new_version=$2
+    local target_branch=$3
 
     generate_changelog $application $new_version $target_branch
     move_to_directory_and_update $application $target_branch


### PR DESCRIPTION
## Problem
The target branch was specified but not passed correctly to the
helper functions, resulting in ill-defined behaviour, including:
- creating releases or tags on the default branch, sometimes this
  was not the master branch, but a dev branch
- creating a new tag onto a (now-stale) commit

## Solution
Pass the target_branch parameter appropriately.

## Note
This highlights the problems with testing some of the fuse-dev-tools
functionality. I suggest a new repo, whose sole purpose is to act as
a test subject for the release-creation script. We can add some
meaningless commits and branches, and run the script against it, even
during local development and testing.