### PR TITLE
chore Document target branch flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,17 @@ Generate a Github personal access token with read-only access to all repos [here
 
 Example usage:
 ```
-GITHUB_ACCESS_TOKEN=a9123012839018239123089123 fuse-dev-tools changelog_generator preview --repo FuseTube
+GITHUB_ACCESS_TOKEN=a9123012839018239123089123 fuse-dev-tools changelog_generator preview --repo FuseTube --target_branch increment-1-2021
 ```
 
 ## Creating a release
 
 To create a release you must type in the command below using the arguments `-a` being the repository name from github you want to release 
-and `-b` for the version increase of the application, which supports the values major, minor, patch and pre. 
+and `-b` for the version increase of the application, which supports the values major, minor, minor-pre (e.g. `x.y.0-pre1`), patch and
+patch-pre (e.g. `x.y.3-pre2`). The argument `-t` specifies the target branch from which to create the release.
 
 Example usage:
-`./bin/create-release -a fuse_courses -b patch`
+`./bin/create-release -a fuse_courses -b patch -t increment-1-2021`
 
 ## Development
 


### PR DESCRIPTION
## Problem
The release creation and changelog generation tools support a (new)
flag to target a specific branch instead of defaulting to HEAD, but
the README does not document this adequately.

Also, the additional bump options (minor-pre and patch-pre) are not
documented.

## Solution
- Document the new target branch flag.
- Document the new bump options.